### PR TITLE
Rnagella/ch16006/remove iadsupport framework in favor of adsupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Implements (mostly) the same API interface on `window.analytics` as [Analytics.j
 ##Segment Write Keys
 In config.xml, you can put the following preferences:
 For iOS
-* \<preference name="analytics_write_key" value="{Segment write key}" />
-* \<preference name="analytics_debug_write_key" value="{Segment write key}" />
+* \<preference name="analytics_ios_write_key" value="{Segment write key}" />
+* \<preference name="analytics_ios_debug_write_key" value="{Segment write key}" />
 For Android
 * \<preference name="analytics_android_write_key" value="{Segment write key}" />
 * \<preference name="analytics_android_debug_write_key" value="{Segment write key}" />

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ Implements (mostly) the same API interface on `window.analytics` as [Analytics.j
 
 ##Segment Write Keys
 In config.xml, you can put the following preferences:
+For iOS
 * \<preference name="analytics_write_key" value="{Segment write key}" />
 * \<preference name="analytics_debug_write_key" value="{Segment write key}" />
+For Android
+* \<preference name="analytics_android_write_key" value="{Segment write key}" />
+* \<preference name="analytics_android_debug_write_key" value="{Segment write key}" />
 
 ##iOS Integrations Setup
 This plugin uses cordova-plugin-cocoapods-support to automatically bundle in the Segment iOS SDK through CocaoPods.

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,9 +47,10 @@
             <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
         </config-file>
 
-        <framework src="com.segment.analytics.android:analytics:4+"/>
+        <!-- <framework src="com.segment.analytics.android:analytics:4+"/> -->
+        <framework src="segment.gradle" custom="true" type="gradleReference" />
         <!-- Automatically tracking lifecycle events https://segment.com/docs/sources/mobile/android/#packaging-device-based-integration-sdks -->
-        <framework src="com.segment.analytics.android.integrations:google-analytics:+" transitive="true"/>
+        <framework src="com.segment.analytics.android.integrations:google-analytics:+"/>
 
         <source-file src="src/android/AnalyticsPlugin.java" target-dir="src/com/segment/analytics/cordova"/>
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,10 +47,7 @@
             <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
         </config-file>
 
-        <!-- <framework src="com.segment.analytics.android:analytics:4+"/> -->
-        <framework src="segment.gradle" custom="true" type="gradleReference" />
-        <!-- Automatically tracking lifecycle events https://segment.com/docs/sources/mobile/android/#packaging-device-based-integration-sdks -->
-        <framework src="com.segment.analytics.android.integrations:google-analytics:+"/>
+        <framework src="com.segment.analytics.android:analytics:4+"/>
 
         <source-file src="src/android/AnalyticsPlugin.java" target-dir="src/com/segment/analytics/cordova"/>
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -70,7 +70,6 @@
         </pods-config>
         <pod id="Analytics" version="3.5.5" />
         <framework src="AdSupport.framework" />
-        <framework src="iAd.framework" />
     </platform>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -69,6 +69,8 @@
         <pods-config ios-min-version="8.0" use-frameworks="true">
         </pods-config>
         <pod id="Analytics" version="3.5.5" />
+        <framework src="AdSupport.framework" />
+        <framework src="iAd.framework" />
     </platform>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -48,6 +48,8 @@
         </config-file>
 
         <framework src="com.segment.analytics.android:analytics:4+"/>
+        <!-- Automatically tracking lifecycle events https://segment.com/docs/sources/mobile/android/#packaging-device-based-integration-sdks -->
+        <framework src="com.segment.analytics.android.integrations:google-analytics:+" transitive="true"/>
 
         <source-file src="src/android/AnalyticsPlugin.java" target-dir="src/com/segment/analytics/cordova"/>
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@
             <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
         </config-file>
 
-        <framework src="com.segment.analytics.android:analytics:4+"/>
+        <framework src="com.segment.analytics.android:analytics:4.2.6"/>
 
         <source-file src="src/android/AnalyticsPlugin.java" target-dir="src/com/segment/analytics/cordova"/>
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,8 +25,8 @@
                 <param name="android-package" value="com.segment.analytics.cordova.AnalyticsPlugin"/>
                 <param name="onload" value="true"/>
             </feature>
-            <preference name="analytics_write_key"/>
-            <preference name="analytics_debug_write_key"/>
+            <preference name="analytics_android_write_key"/>
+            <preference name="analytics_android_debug_write_key"/>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
@@ -62,8 +62,8 @@
                 <param name="ios-package" value="AnalyticsPlugin" />
                 <param name="onload" value="true"/>
             </feature>
-            <preference name="analytics_write_key"/>
-            <preference name="analytics_debug_write_key"/>
+            <preference name="analytics_ios_write_key"/>
+            <preference name="analytics_ios_debug_write_key"/>
         </config-file>
 
         <header-file src="src/ios/AnalyticsPlugin.h" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,8 +25,8 @@
                 <param name="android-package" value="com.segment.analytics.cordova.AnalyticsPlugin"/>
                 <param name="onload" value="true"/>
             </feature>
-            <preference name="analytics_write_key"/>
-            <preference name="analytics_debug_write_key"/>
+            <preference name="analytics_android_write_key"/>
+            <preference name="analytics_android_debug_write_key"/>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,8 +25,8 @@
                 <param name="android-package" value="com.segment.analytics.cordova.AnalyticsPlugin"/>
                 <param name="onload" value="true"/>
             </feature>
-            <preference name="analytics_android_write_key"/>
-            <preference name="analytics_android_debug_write_key"/>
+            <preference name="analytics_write_key"/>
+            <preference name="analytics_debug_write_key"/>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,8 +25,6 @@
                 <param name="android-package" value="com.segment.analytics.cordova.AnalyticsPlugin"/>
                 <param name="onload" value="true"/>
             </feature>
-            <preference name="analytics_android_write_key" value="xyz"/>
-            <preference name="analytics_android_debug_write_key" value="123"/>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,8 +25,8 @@
                 <param name="android-package" value="com.segment.analytics.cordova.AnalyticsPlugin"/>
                 <param name="onload" value="true"/>
             </feature>
-            <preference name="analytics_android_write_key"/>
-            <preference name="analytics_android_debug_write_key"/>
+            <preference name="analytics_android_write_key" value="xyz"/>
+            <preference name="analytics_android_debug_write_key" value="123"/>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">

--- a/segment.gradle
+++ b/segment.gradle
@@ -1,0 +1,3 @@
+compile('com.segment.analytics.android:analytics:+') {
+  transitive = true
+}

--- a/segment.gradle
+++ b/segment.gradle
@@ -1,3 +1,0 @@
-compile('com.segment.analytics.android:analytics:+') {
-  transitive = true
-}

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -51,7 +51,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
         } else {
             Log.e(TAG, "Analytics: " + analytics);
             Log.e(TAG, "Initializing Segment Analytics " + writeKey);
-            if (!analytics) {
+            if (analytics == null) {
                 analytics = new Analytics.Builder(
                     cordova.getActivity().getApplicationContext(),
                     writeKey

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -30,7 +30,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
     private Analytics analytics;
     private String writeKey;
 
-    @Override protected void pluginInitialize() {
+    @Override protected void onCreate() {
         String writeKeyPreferenceName;
         LogLevel logLevel;
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -34,12 +34,13 @@ public class AnalyticsPlugin extends CordovaPlugin {
         String writeKeyPreferenceName;
         LogLevel logLevel;
 
+        // BuildConfig.APPLICATION_ID returns org.apache.cordova instead com.shipt.shopper-staging or com.shipt.shopper or com.shipt.shopper-enterprise due to which I could not able to set keys based on string search. Please see other possible ways to get the APPLICATION_ID.
         if(BuildConfig.DEBUG) {
-            writeKeyPreferenceName = "analytics_debug_write_key";
+            writeKeyPreferenceName = "analytics_android_debug_write_key";
             logLevel = LogLevel.VERBOSE;
         } else {
-            writeKeyPreferenceName = "analytics_write_key";
-            logLevel = LogLevel.VERBOSE;
+            writeKeyPreferenceName = "analytics_android_write_key";
+            logLevel = LogLevel.NONE;
         }
 
         writeKey = this.preferences.getString(writeKeyPreferenceName, null);

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -34,11 +34,11 @@ public class AnalyticsPlugin extends CordovaPlugin {
         String writeKeyPreferenceName;
         LogLevel logLevel;
 
-        if(BuildConfig.DEBUG) {
-            writeKeyPreferenceName = "analytics_debug_write_key";
+        if((BuildConfig.APPLICATION_ID).contains("staging")) {
+            writeKeyPreferenceName = "analytics_android_debug_write_key";
             logLevel = LogLevel.VERBOSE;
         } else {
-            writeKeyPreferenceName = "analytics_write_key";
+            writeKeyPreferenceName = "analytics_android_write_key";
             logLevel = LogLevel.NONE;
         }
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -65,7 +65,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
         }
     }
     
-    @Override public void onResume() {
+    @Override public void onResume(boolean multitasking) {
         Log.e(TAG, "onResume called");
     }
     

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -57,6 +57,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
                 writeKey
             )
             .logLevel(logLevel)
+            .collectDeviceId(true)
             .trackApplicationLifecycleEvents()
             .build();
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -55,7 +55,8 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = new Analytics.Builder(
                 cordova.getActivity().getApplicationContext(),
                 writeKey
-            ).logLevel(logLevel).
+            )
+            .logLevel(logLevel)
             .use(GoogleAnalyticsIntegration.FACTORY)
             .trackApplicationLifecycleEvents()
             .build();

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -57,7 +57,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
                 ).logLevel(logLevel).build();
                 Log.e(TAG, "Analytics set to: " + analytics);
 
-                Analytics.setSingletonInstance(analytics);
+                //Analytics.setSingletonInstance(analytics);
             } catch (Exception e) {
                 Log.e(TAG, "Segment Error " + e.getMessage());
                 Log.e(TAG, "Segment Analytics already set " + writeKey);

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -31,6 +31,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
     private String writeKey;
 
     @Override protected void pluginInitialize() {
+        reset();
         String writeKeyPreferenceName;
         LogLevel logLevel;
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -49,21 +49,14 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = null;
             Log.e(TAG, "Invalid write key: " + writeKey);
         } else {
-            try {
-                Log.e(TAG, "Initializing Segment Analytics " + writeKey);
-                analytics = new Analytics.Builder(
-                    cordova.getActivity().getApplicationContext(),
-                    writeKey
-                ).logLevel(logLevel).build();
-                Log.e(TAG, "Analytics set to: " + analytics);
-
-                //Analytics.setSingletonInstance(analytics);
-            } catch (Exception e) {
-                Log.e(TAG, "Segment Error " + e.getMessage());
-                Log.e(TAG, "Segment Analytics already set " + writeKey);
-                Log.e(TAG, "Analytics alreadt set to: " + analytics);
-            }
+            Log.e(TAG, "Initializing Segment Analytics " + writeKey);
+            analytics = new Analytics.Builder(
+                cordova.getActivity().getApplicationContext(),
+                writeKey
+            ).logLevel(logLevel).build();
+            Log.e(TAG, "Analytics set to: " + analytics);
             
+            Analytics.setSingletonInstance(analytics);
         }
     }
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -30,7 +30,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
     private Analytics analytics;
     private String writeKey;
 
-    @Override protected void onCreate() {
+    @Override protected void pluginInitialize() {
         String writeKeyPreferenceName;
         LogLevel logLevel;
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -52,13 +52,24 @@ public class AnalyticsPlugin extends CordovaPlugin {
             Log.e(TAG, "Invalid write key: " + writeKey);
         } else {
             // trackApplicationLifecycleEvents() -> Enable this to record certain application events automatically! -> which then used by Tune to map install attributions https://segment.com/docs/sources/mobile/android/quickstart/#step-2-initialize-the-client
+
+            // trackApplicationLifecycleEvents - is not getting fired due to ` segment` initializing is getting done on onActivityStarted instead on onActivityCreated. Where segment logic of `trackApplicationLifecycleEvents` is handled with in `onActivityCreated` https://github.com/segmentio/analytics-android/blob/master/analytics/src/main/java/com/segment/analytics/Analytics.java#L291
+
+            // analytics = new Analytics.Builder(
+            //     cordova.getActivity().getApplicationContext(),
+            //     writeKey
+            // )
+            // .logLevel(logLevel)
+            // .collectDeviceId(true)
+            // .trackApplicationLifecycleEvents()
+            // .build();
+
             analytics = new Analytics.Builder(
                 cordova.getActivity().getApplicationContext(),
                 writeKey
             )
             .logLevel(logLevel)
             .collectDeviceId(true)
-            .trackApplicationLifecycleEvents()
             .build();
 
             Analytics.setSingletonInstance(analytics);

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -31,7 +31,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
     private static final String TAG = "AnalyticsPlugin";
     private Analytics analytics;
     private String writeKey;
-    
+
     @Override protected void pluginInitialize() {
         String writeKeyPreferenceName;
         LogLevel logLevel;
@@ -51,19 +51,22 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = null;
             Log.e(TAG, "Invalid write key: " + writeKey);
         } else {
+            // trackApplicationLifecycleEvents() -> Enable this to record certain application events automatically! -> which then used by Tune to map install attributions https://segment.com/docs/sources/mobile/android/quickstart/#step-2-initialize-the-client
             analytics = new Analytics.Builder(
                 cordova.getActivity().getApplicationContext(),
                 writeKey
-            ).logLevel(logLevel).build();
+            ).logLevel(logLevel)
+            .trackApplicationLifecycleEvents()
+            .build();
 
             Analytics.setSingletonInstance(analytics);
         }
     }
-    
-    /** On android, when closing the app via the back button, a relaunch tries to reinitialize the segment instance. 
+
+    /** On android, when closing the app via the back button, a relaunch tries to reinitialize the segment instance.
     *   This causes a crash because the segment instance is already initialized as a singleton. So. We need to kill
     *   the current process on destroy in order to allow the app to relaunch and initialize segment successfully.
-    *   
+    *
     *  ... fucking android
     **/
     @Override

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import android.app.Activity;
+
 public class AnalyticsPlugin extends CordovaPlugin {
 
     private static final String TAG = "AnalyticsPlugin";

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -34,13 +34,15 @@ public class AnalyticsPlugin extends CordovaPlugin {
         String writeKeyPreferenceName;
         LogLevel logLevel;
 
-        if(this.cordova.getActivity().getPackageName().contains("staging")) {
-            writeKeyPreferenceName = "analytics_android_debug_write_key";
+        if(BuildConfig.DEBUG) {
+            writeKeyPreferenceName = "analytics_debug_write_key";
             logLevel = LogLevel.VERBOSE;
         } else {
-            writeKeyPreferenceName = "analytics_android_write_key";
+            writeKeyPreferenceName = "analytics_write_key";
             logLevel = LogLevel.NONE;
         }
+
+        writeKey = this.preferences.getString(writeKeyPreferenceName, null);
 
         if (writeKey == null || "".equals(writeKey)) {
             analytics = null;

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -39,7 +39,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
             logLevel = LogLevel.VERBOSE;
         } else {
             writeKeyPreferenceName = "analytics_write_key";
-            logLevel = LogLevel.NONE;
+            logLevel = LogLevel.VERBOSE;
         }
 
         writeKey = this.preferences.getString(writeKeyPreferenceName, null);

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -51,30 +51,25 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = null;
             Log.e(TAG, "Invalid write key: " + writeKey);
         } else {
-            Log.e(TAG, "Analytics: " + analytics);
-            Log.e(TAG, "Initializing Segment Analytics " + writeKey);
             analytics = new Analytics.Builder(
                 cordova.getActivity().getApplicationContext(),
                 writeKey
             ).logLevel(logLevel).build();
-            Log.e(TAG, "Analytics set to: " + analytics);
 
             Analytics.setSingletonInstance(analytics);
         }
     }
     
-    @Override public void onResume(boolean multitasking) {
-        Log.e(TAG, "onResume called");
-    }
-    
+    /** On android, when closing the app via the back button, a relaunch tries to reinitialize the segment instance. 
+    *   This causes a crash because the segment instance is already initialized as a singleton. So. We need to kill
+    *   the current process on destroy in order to allow the app to relaunch and initialize segment successfully.
+    *   
+    *  ... fucking android
+    **/
     @Override
     public void onDestroy() {
        int pid = android.os.Process.myPid();
        android.os.Process.killProcess(pid);
-    }
-    
-    @Override public void onStop() {
-        Log.e(TAG, "onStop called");
     }
 
     @Override

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -31,7 +31,6 @@ public class AnalyticsPlugin extends CordovaPlugin {
     private String writeKey;
 
     @Override protected void pluginInitialize() {
-        reset();
         String writeKeyPreferenceName;
         LogLevel logLevel;
 
@@ -50,14 +49,19 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = null;
             Log.e(TAG, "Invalid write key: " + writeKey);
         } else {
+            Log.e(TAG, "Analytics: " + analytics);
             Log.e(TAG, "Initializing Segment Analytics " + writeKey);
-            analytics = new Analytics.Builder(
-                cordova.getActivity().getApplicationContext(),
-                writeKey
-            ).logLevel(logLevel).build();
-            Log.e(TAG, "Analytics set to: " + analytics);
-            
-            Analytics.setSingletonInstance(analytics);
+            if (!analytics) {
+                analytics = new Analytics.Builder(
+                    cordova.getActivity().getApplicationContext(),
+                    writeKey
+                ).logLevel(logLevel).build();
+                Log.e(TAG, "Analytics set to: " + analytics);
+
+                Analytics.setSingletonInstance(analytics);
+            } else {
+                Log.e(TAG, "Analytics already set to: " + analytics);
+            }
         }
     }
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import android.app.Activity;
+import android.os.Bundle;
 
 public class AnalyticsPlugin extends CordovaPlugin {
 
@@ -32,7 +33,8 @@ public class AnalyticsPlugin extends CordovaPlugin {
     private Analytics analytics;
     private String writeKey;
     
-    @Override public void onStart() {
+    @Override public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
         String writeKeyPreferenceName;
         LogLevel logLevel;
 
@@ -69,8 +71,6 @@ public class AnalyticsPlugin extends CordovaPlugin {
     
     @Override public void onDestroy() {
         Log.e(TAG, "onDestroy called");
-        Activity activity = this.cordova.getActivity();
-        activity.finish();
     }
     
     @Override public void onStop() {

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -75,6 +75,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
     
     @Override public void onStop() {
         Log.e(TAG, "onStop called");
+        analytics.shutdown();
     }
 
     @Override protected void pluginInitialize() {

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -36,36 +36,29 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
         // BuildConfig.APPLICATION_ID returns org.apache.cordova instead com.shipt.shopper-staging or com.shipt.shopper or com.shipt.shopper-enterprise due to which I could not able to set keys based on string search. Please see other possible ways to get the APPLICATION_ID.
         if(BuildConfig.DEBUG) {
-//             writeKeyPreferenceName = "analytics_debug_write_key";
+            writeKeyPreferenceName = "analytics_android_debug_write_key";
             logLevel = LogLevel.VERBOSE;
         } else {
-//             writeKeyPreferenceName = "analytics_android_write_key";
+            writeKeyPreferenceName = "analytics_android_write_key";
             logLevel = LogLevel.NONE;
         }
-        
-        analytics = Analytics.with(cordova.getActivity().getApplicationContext());
 
-//         writeKey = this.preferences.getString(writeKeyPreferenceName, null);
+        writeKey = this.preferences.getString(writeKeyPreferenceName, null);
 
-//         if (writeKey == null || "".equals(writeKey)) {
-//             analytics = null;
-//             Log.e(TAG, "Invalid write key: " + writeKey);
-//         } else {
-//             Log.e(TAG, "Analytics: " + analytics);
-//             Log.e(TAG, "Initializing Segment Analytics " + writeKey);
-// //             analytics = Analytics.with(cordova.getActivity().getApplicationContext());
-//             if ( == null) {
-//                 analytics = new Analytics.Builder(
-//                     cordova.getActivity().getApplicationContext(),
-//                     writeKey
-//                 ).logLevel(logLevel).build();
-//                 Log.e(TAG, "Analytics set to: " + analytics);
+        if (writeKey == null || "".equals(writeKey)) {
+            analytics = null;
+            Log.e(TAG, "Invalid write key: " + writeKey);
+        } else {
+            Log.e(TAG, "Analytics: " + analytics);
+            Log.e(TAG, "Initializing Segment Analytics " + writeKey);
+            analytics = new Analytics.Builder(
+                cordova.getActivity().getApplicationContext(),
+                writeKey
+            ).logLevel(logLevel).build();
+            Log.e(TAG, "Analytics set to: " + analytics);
 
-//                 Analytics.setSingletonInstance(analytics);
-//             } else {
-//                 Log.e(TAG, "Analytics already set to: " + analytics);
-//             }
-//         }
+            Analytics.setSingletonInstance(analytics);
+        }
     }
     
     @Override public void onResume(boolean multitasking) {
@@ -74,6 +67,8 @@ public class AnalyticsPlugin extends CordovaPlugin {
     
     @Override public void onDestroy() {
         Log.e(TAG, "onDestroy called");
+        Activity activity = this.cordova.getActivity();
+        activity.finish();
     }
     
     @Override public void onStop() {

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -71,11 +71,11 @@ public class AnalyticsPlugin extends CordovaPlugin {
     
     @Override public void onDestroy() {
         Log.e(TAG, "onDestroy called");
+        analytics.shutdown();
     }
     
     @Override public void onStop() {
         Log.e(TAG, "onStop called");
-        analytics.shutdown();
     }
 
     @Override protected void pluginInitialize() {

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -55,7 +55,8 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = new Analytics.Builder(
                 cordova.getActivity().getApplicationContext(),
                 writeKey
-            ).logLevel(logLevel)
+            ).logLevel(logLevel).
+            .use(GoogleAnalyticsIntegration.FACTORY)
             .trackApplicationLifecycleEvents()
             .build();
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -29,8 +29,8 @@ public class AnalyticsPlugin extends CordovaPlugin {
     private static final String TAG = "AnalyticsPlugin";
     private Analytics analytics;
     private String writeKey;
-
-    @Override protected void pluginInitialize() {
+    
+    @Override public void onStart() {
         String writeKeyPreferenceName;
         LogLevel logLevel;
 
@@ -63,6 +63,22 @@ public class AnalyticsPlugin extends CordovaPlugin {
                 Log.e(TAG, "Analytics already set to: " + analytics);
             }
         }
+    }
+    
+    @Override public void onResume() {
+        Log.e(TAG, "onResume called");
+    }
+    
+    @Override public void onDestroy() {
+        Log.e(TAG, "onDestroy called");
+    }
+    
+    @Override public void onStop() {
+        Log.e(TAG, "onStop called");
+    }
+
+    @Override protected void pluginInitialize() {
+        Log.e(TAG, "pluginInitialize called");
     }
 
     @Override

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -49,6 +49,7 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = null;
             Log.e(TAG, "Invalid write key: " + writeKey);
         } else {
+            analytics = null;
             Log.e(TAG, "Iniitializing Segment Analytics " + writeKey);
             analytics = new Analytics.Builder(
                 cordova.getActivity().getApplicationContext(),

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -36,33 +36,36 @@ public class AnalyticsPlugin extends CordovaPlugin {
 
         // BuildConfig.APPLICATION_ID returns org.apache.cordova instead com.shipt.shopper-staging or com.shipt.shopper or com.shipt.shopper-enterprise due to which I could not able to set keys based on string search. Please see other possible ways to get the APPLICATION_ID.
         if(BuildConfig.DEBUG) {
-            writeKeyPreferenceName = "analytics_android_debug_write_key";
+//             writeKeyPreferenceName = "analytics_debug_write_key";
             logLevel = LogLevel.VERBOSE;
         } else {
-            writeKeyPreferenceName = "analytics_android_write_key";
+//             writeKeyPreferenceName = "analytics_android_write_key";
             logLevel = LogLevel.NONE;
         }
+        
+        analytics = Analytics.with(cordova.getActivity().getApplicationContext());
 
-        writeKey = this.preferences.getString(writeKeyPreferenceName, null);
+//         writeKey = this.preferences.getString(writeKeyPreferenceName, null);
 
-        if (writeKey == null || "".equals(writeKey)) {
-            analytics = null;
-            Log.e(TAG, "Invalid write key: " + writeKey);
-        } else {
-            Log.e(TAG, "Analytics: " + analytics);
-            Log.e(TAG, "Initializing Segment Analytics " + writeKey);
-            if (analytics == null) {
-                analytics = new Analytics.Builder(
-                    cordova.getActivity().getApplicationContext(),
-                    writeKey
-                ).logLevel(logLevel).build();
-                Log.e(TAG, "Analytics set to: " + analytics);
+//         if (writeKey == null || "".equals(writeKey)) {
+//             analytics = null;
+//             Log.e(TAG, "Invalid write key: " + writeKey);
+//         } else {
+//             Log.e(TAG, "Analytics: " + analytics);
+//             Log.e(TAG, "Initializing Segment Analytics " + writeKey);
+// //             analytics = Analytics.with(cordova.getActivity().getApplicationContext());
+//             if ( == null) {
+//                 analytics = new Analytics.Builder(
+//                     cordova.getActivity().getApplicationContext(),
+//                     writeKey
+//                 ).logLevel(logLevel).build();
+//                 Log.e(TAG, "Analytics set to: " + analytics);
 
-                Analytics.setSingletonInstance(analytics);
-            } else {
-                Log.e(TAG, "Analytics already set to: " + analytics);
-            }
-        }
+//                 Analytics.setSingletonInstance(analytics);
+//             } else {
+//                 Log.e(TAG, "Analytics already set to: " + analytics);
+//             }
+//         }
     }
     
     @Override public void onResume(boolean multitasking) {

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -49,10 +49,12 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = null;
             Log.e(TAG, "Invalid write key: " + writeKey);
         } else {
+            Log.e(TAG, "Iniitializing Segment Analytics " + writeKey);
             analytics = new Analytics.Builder(
                 cordova.getActivity().getApplicationContext(),
                 writeKey
             ).logLevel(logLevel).build();
+            Log.e(TAG, "Analytics set to: " + analytics);
 
             Analytics.setSingletonInstance(analytics);
         }

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -24,17 +24,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import android.app.Activity;
-import android.os.Bundle;
-
 public class AnalyticsPlugin extends CordovaPlugin {
 
     private static final String TAG = "AnalyticsPlugin";
     private Analytics analytics;
     private String writeKey;
     
-    @Override public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    @Override protected void pluginInitialize() {
         String writeKeyPreferenceName;
         LogLevel logLevel;
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -77,10 +77,6 @@ public class AnalyticsPlugin extends CordovaPlugin {
         Log.e(TAG, "onStop called");
     }
 
-    @Override protected void pluginInitialize() {
-        Log.e(TAG, "pluginInitialize called");
-    }
-
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         if (analytics == null) {

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -49,15 +49,21 @@ public class AnalyticsPlugin extends CordovaPlugin {
             analytics = null;
             Log.e(TAG, "Invalid write key: " + writeKey);
         } else {
-            analytics = null;
-            Log.e(TAG, "Iniitializing Segment Analytics " + writeKey);
-            analytics = new Analytics.Builder(
-                cordova.getActivity().getApplicationContext(),
-                writeKey
-            ).logLevel(logLevel).build();
-            Log.e(TAG, "Analytics set to: " + analytics);
+            try {
+                Log.e(TAG, "Initializing Segment Analytics " + writeKey);
+                analytics = new Analytics.Builder(
+                    cordova.getActivity().getApplicationContext(),
+                    writeKey
+                ).logLevel(logLevel).build();
+                Log.e(TAG, "Analytics set to: " + analytics);
 
-            Analytics.setSingletonInstance(analytics);
+                Analytics.setSingletonInstance(analytics);
+            } catch (Exception e) {
+                Log.e(TAG, "Segment Error " + e.getMessage());
+                Log.e(TAG, "Segment Analytics already set " + writeKey);
+                Log.e(TAG, "Analytics alreadt set to: " + analytics);
+            }
+            
         }
     }
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import android.os.Process;
+
 public class AnalyticsPlugin extends CordovaPlugin {
 
     private static final String TAG = "AnalyticsPlugin";
@@ -65,8 +67,10 @@ public class AnalyticsPlugin extends CordovaPlugin {
         Log.e(TAG, "onResume called");
     }
     
-    @Override public void onDestroy() {
-        Log.e(TAG, "onDestroy called");
+    @Override
+    public void onDestroy() {
+       int pid = android.os.Process.myPid();
+       android.os.Process.killProcess(pid);
     }
     
     @Override public void onStop() {

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -34,15 +34,13 @@ public class AnalyticsPlugin extends CordovaPlugin {
         String writeKeyPreferenceName;
         LogLevel logLevel;
 
-        if((BuildConfig.APPLICATION_ID).contains("staging")) {
+        if(this.cordova.getActivity().getPackageName().contains("staging")) {
             writeKeyPreferenceName = "analytics_android_debug_write_key";
             logLevel = LogLevel.VERBOSE;
         } else {
             writeKeyPreferenceName = "analytics_android_write_key";
             logLevel = LogLevel.NONE;
         }
-
-        writeKey = this.preferences.getString(writeKeyPreferenceName, null);
 
         if (writeKey == null || "".equals(writeKey)) {
             analytics = null;

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -57,7 +57,6 @@ public class AnalyticsPlugin extends CordovaPlugin {
                 writeKey
             )
             .logLevel(logLevel)
-            .use(GoogleAnalyticsIntegration.FACTORY)
             .trackApplicationLifecycleEvents()
             .build();
 

--- a/src/android/AnalyticsPlugin.java
+++ b/src/android/AnalyticsPlugin.java
@@ -74,7 +74,6 @@ public class AnalyticsPlugin extends CordovaPlugin {
     
     @Override public void onDestroy() {
         Log.e(TAG, "onDestroy called");
-        analytics.shutdown();
     }
     
     @Override public void onStop() {

--- a/src/ios/AnalyticsPlugin.m
+++ b/src/ios/AnalyticsPlugin.m
@@ -46,7 +46,7 @@
 
         SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:writeKey];
         configuration.shouldUseLocationServices = [useLocationServices boolValue];
-        configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically! which then used by Tune to map install attributions -> https://segment.com/docs/spec/mobile/#lifecycle-events
+        // configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically! which then used by Tune to map install attributions -> https://segment.com/docs/spec/mobile/#lifecycle-events
         [SEGAnalytics setupWithConfiguration:configuration];
     } else {
         NSLog(@"[cordova-plugin-segment] ERROR - Invalid write key");

--- a/src/ios/AnalyticsPlugin.m
+++ b/src/ios/AnalyticsPlugin.m
@@ -31,11 +31,11 @@
 
     if ([appID rangeOfString:@"staging"].location == NSNotFound) {
         // Prod
-        writeKeyPreferenceName = @"analytics_write_key";
+        writeKeyPreferenceName = @"analytics_ios_write_key";
         writeKeyPListName = @"AnalyticsWriteKey";
     } else {
         // Non-Prod
-        writeKeyPreferenceName = @"analytics_debug_write_key";
+        writeKeyPreferenceName = @"analytics_ios_debug_write_key";
         writeKeyPListName = @"AnalyticsDebugWriteKey";
     }
 

--- a/src/ios/AnalyticsPlugin.m
+++ b/src/ios/AnalyticsPlugin.m
@@ -15,17 +15,31 @@
 {
     NSString* writeKeyPreferenceName;
     NSString* writeKeyPListName;
-
+    // Note: Overwrite to set keys based on app id's
     //Get app credentials from config.xml or the info.plist if they can't be found
-    #ifdef DEBUG
-        [SEGAnalytics debug:YES];
-        writeKeyPreferenceName = @"analytics_debug_write_key";
-        writeKeyPListName = @"AnalyticsDebugWriteKey";
-    #else
-        [SEGAnalytics debug:NO];
+    // #ifdef DEBUG
+    //     [SEGAnalytics debug:YES];
+    //     writeKeyPreferenceName = @"analytics_debug_write_key";
+    //     writeKeyPListName = @"AnalyticsDebugWriteKey";
+    // #else
+    //     [SEGAnalytics debug:NO];
+    //     writeKeyPreferenceName = @"analytics_write_key";
+    //     writeKeyPListName = @"AnalyticsWriteKey";
+    // #endif
+
+    NSString* appID = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
+
+    NSLog(@"[cordova-plugin-segment] appID %@", appID);
+
+    if ([appID  isEqual: @"com.shipt.groceries"]) {
+        // Prod keys
         writeKeyPreferenceName = @"analytics_write_key";
         writeKeyPListName = @"AnalyticsWriteKey";
-    #endif
+    } else {
+        // Non-Prod keys
+        writeKeyPreferenceName = @"analytics_debug_write_key";
+        writeKeyPListName = @"AnalyticsDebugWriteKey";
+    }
 
     NSString* writeKey = self.commandDelegate.settings[writeKeyPreferenceName] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:writeKeyPListName];
 

--- a/src/ios/AnalyticsPlugin.m
+++ b/src/ios/AnalyticsPlugin.m
@@ -29,14 +29,12 @@
 
     NSString* appID = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
 
-    NSLog(@"[cordova-plugin-segment] appID %@", appID);
-
-    if ([appID  isEqual: @"com.shipt.groceries"]) {
-        // Prod keys
+    if ([appID rangeOfString:@"staging"].location == NSNotFound) {
+        // Prod
         writeKeyPreferenceName = @"analytics_write_key";
         writeKeyPListName = @"AnalyticsWriteKey";
     } else {
-        // Non-Prod keys
+        // Non-Prod
         writeKeyPreferenceName = @"analytics_debug_write_key";
         writeKeyPListName = @"AnalyticsDebugWriteKey";
     }

--- a/src/ios/AnalyticsPlugin.m
+++ b/src/ios/AnalyticsPlugin.m
@@ -46,6 +46,7 @@
 
         SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:writeKey];
         configuration.shouldUseLocationServices = [useLocationServices boolValue];
+        configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically! which then used by Tune to map install attributions -> https://segment.com/docs/spec/mobile/#lifecycle-events
         [SEGAnalytics setupWithConfiguration:configuration];
     } else {
         NSLog(@"[cordova-plugin-segment] ERROR - Invalid write key");


### PR DESCRIPTION
I believe there is no need of iAdSupport framework as suggested here all we need is AdSupport framework - https://segment.com/docs/integrations/tune/#ios-setup

Less library will result in faster app startup.